### PR TITLE
Changes to help run on ancient OpenGL platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.sln
 *.vcxproj.filters
 *.vcxproj.user
+neosu
 
 .cache/
 build/

--- a/src/Engine/Renderer/OpenGL/OpenGLVertexArrayObject.cpp
+++ b/src/Engine/Renderer/OpenGL/OpenGLVertexArrayObject.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2017, PG, All rights reserved.
 #include "OpenGLVertexArrayObject.h"
+#include <SDL3/SDL_video.h>
 
 #ifdef MCENGINE_FEATURE_OPENGL
 
@@ -91,6 +92,14 @@ void OpenGLVertexArrayObject::init() {
         glBindVertexArray(this->iVertexArray);
     }
 
+    // Need to manually load extensions on older OpenGL platforms
+    if (!glGenBuffers || !glBindBuffer || !glBufferData)
+    {
+        glGenBuffers = (PFNGLGENBUFFERSPROC)SDL_GL_GetProcAddress("glGenBuffers");
+        glBindBuffer = (PFNGLBINDBUFFERPROC)SDL_GL_GetProcAddress("glBindBuffer");
+        glBufferData = (PFNGLBUFFERDATAPROC)SDL_GL_GetProcAddress("glBufferData");
+    }
+
     // build and fill vertex buffer
     {
         glGenBuffers(1, &this->iVertexBuffer);
@@ -180,6 +189,10 @@ void OpenGLVertexArrayObject::initAsync() { this->bAsyncReady = true; }
 
 void OpenGLVertexArrayObject::destroy() {
     VertexArrayObject::destroy();
+
+    // Need to manually load extensions on older OpenGL platforms
+    if (!glDeleteBuffers)
+        glDeleteBuffers = (PFNGLDELETEBUFFERSPROC)SDL_GL_GetProcAddress("glDeleteBuffers");
 
     if(this->iVertexBuffer > 0) glDeleteBuffers(1, &this->iVertexBuffer);
 

--- a/src/Platform/main_impl.cpp
+++ b/src/Platform/main_impl.cpp
@@ -346,9 +346,7 @@ static constexpr auto WINDOW_HEIGHT_MIN = 240;
 bool SDLMain::createWindow() {
     // pre window-creation settings
     if constexpr(Env::cfg((REND::GL | REND::GLES32), !REND::DX11)) {
-        SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
-                            Env::cfg(REND::GL) ? SDL_GL_CONTEXT_PROFILE_COMPATIBILITY : SDL_GL_CONTEXT_PROFILE_ES);
+        SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 0);
         if constexpr(!Env::cfg(REND::GL)) {
             SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
             SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);


### PR DESCRIPTION
It runs on my ASUS Eee PC on Arch Linux 32 without crashing on the main menu cube or the options menu now. I've yet to test gameplay though, so you can leave this open until I do that if you want.