### PR TITLE
refactor beatmap importing

### DIFF
--- a/src/App/Neomod/BeatmapInstaller.cpp
+++ b/src/App/Neomod/BeatmapInstaller.cpp
@@ -9,18 +9,13 @@
 #include "Downloader.h"
 #include "Engine.h"
 #include "Environment.h"
-#include "File.h"
-#include "FixedSizeArray.h"
 #include "i18n.h"
 #include "Logging.h"
 #include "NotificationOverlay.h"
 #include "Osu.h"
 #include "OsuConfig.h"
-#include "Parsing.h"
 #include "SongBrowser/SongBrowser.h"
 #include "UI.h"
-
-#include <cctype>
 
 void BeatmapInstaller::enqueue(i32 set_id, bool auto_select, std::string_view display_name) {
     if(set_id <= 0) return;
@@ -132,12 +127,9 @@ void BeatmapInstaller::update() {
             }
 
             case Installing: {
-                // defensive: only import while db isn't being rebuilt. db->isFinished() flips back to <1
-                // during a refresh, and addBeatmapSet would race the loader.
-                if(!db->isFinished() || db->isCancelled()) break;
+                auto [set, imported, ready] = this->try_import(set_id);
+                if(!ready) break;  // db busy/rebuilding; retry next tick
 
-                const std::string mapset_path = fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id);
-                auto [set, imported] = db->addBeatmapSet(mapset_path, set_id);
                 if(set == nullptr) {
                     e.stage = Failed;
                     e.finished_time = now;
@@ -180,25 +172,7 @@ void BeatmapInstaller::update() {
             case Queued: {
                 // read + decompress + extract on a worker so the main thread never blocks on it.
                 le.extract_future = Async::submit(
-                    [path = le.osz_path]() -> i32 {
-                        FixedSizeArray<u8> osz_data;
-                        {
-                            File osz(path);
-                            const uSz filesize = osz.getFileSize();
-                            osz_data = FixedSizeArray{osz.takeFileBuffer(), filesize};
-                            if(!osz.canRead() || !filesize || !osz_data.data()) return -1;
-                        }
-
-                        // fallback id: a leading number in the filename, e.g. "12345 Artist - Title.osz"
-                        i32 fallback_id = -1;
-                        std::string name = Environment::getFileNameFromFilePath(path);
-                        if(!name.empty() && std::isdigit(static_cast<unsigned char>(name[0]))) {
-                            if(!Parsing::parse(name, &fallback_id)) fallback_id = -1;
-                        }
-
-                        return Downloader::resolve_and_extract_osz(osz_data, name, fallback_id);
-                    },
-                    Lane::Background);
+                    [path = le.osz_path]() -> i32 { return Downloader::read_and_extract_osz(path); }, Lane::Background);
                 le.stage = Extracting;
                 break;
             }
@@ -219,12 +193,9 @@ void BeatmapInstaller::update() {
             }
 
             case Installing: {
-                // same guard as downloads: don't import while the database is being (re)built.
-                // TODO: dedup
-                if(!db->isFinished() || db->isCancelled()) break;
+                auto [set, imported, ready] = this->try_import(le.set_id);
+                if(!ready) break;  // db busy/rebuilding; retry next tick
 
-                const std::string mapset_path = fmt::format(NEOMOD_MAPS_PATH "/{}/", le.set_id);
-                auto [set, imported] = db->addBeatmapSet(mapset_path, le.set_id);
                 if(set == nullptr) {
                     le.stage = Failed;
                     le.finished_time = now;
@@ -254,6 +225,15 @@ void BeatmapInstaller::update() {
             ++it;
         }
     }
+}
+
+BeatmapInstaller::ImportResult BeatmapInstaller::try_import(i32 set_id) {
+    // db->isFinished() drops below 1 during a refresh; importing then would race the loader thread
+    // appending to beatmapsets, so wait for it to settle (the caller retries next tick).
+    if(!db->isFinished() || db->isCancelled()) return {};
+
+    auto [set, added] = db->addBeatmapSet(fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id), set_id);
+    return {set, added, true};
 }
 
 void BeatmapInstaller::on_done(BeatmapSet* set, i32 set_id, bool added, bool auto_select) {

--- a/src/App/Neomod/BeatmapInstaller.cpp
+++ b/src/App/Neomod/BeatmapInstaller.cpp
@@ -2,17 +2,25 @@
 
 #include "BeatmapInstaller.h"
 
+#include "AsyncPool.h"
+#include "AsyncTypes.h"
 #include "Database.h"
 #include "DatabaseBeatmap.h"
 #include "Downloader.h"
 #include "Engine.h"
+#include "Environment.h"
+#include "File.h"
+#include "FixedSizeArray.h"
 #include "i18n.h"
 #include "Logging.h"
 #include "NotificationOverlay.h"
 #include "Osu.h"
 #include "OsuConfig.h"
+#include "Parsing.h"
 #include "SongBrowser/SongBrowser.h"
 #include "UI.h"
+
+#include <cctype>
 
 void BeatmapInstaller::enqueue(i32 set_id, bool auto_select, std::string_view display_name) {
     if(set_id <= 0) return;
@@ -39,6 +47,26 @@ void BeatmapInstaller::enqueue(i32 set_id, bool auto_select, std::string_view di
         e.finished_time = 0.0;
         e.stage = MapInstallStage::Queued;
     }
+}
+
+void BeatmapInstaller::enqueue_local(std::string osz_path, bool auto_select, bool delete_after) {
+    if(osz_path.empty()) return;
+
+    // de-dupe by path so the same file scanned/dropped twice doesn't import twice; a later request
+    // to navigate to it still takes effect once it lands.
+    for(LocalEntry& existing : this->local_imports) {
+        if(existing.osz_path == osz_path) {
+            if(auto_select) existing.auto_select = true;
+            return;
+        }
+    }
+
+    LocalEntry le;
+    le.osz_path = std::move(osz_path);
+    le.auto_select = auto_select;
+    le.delete_after = delete_after;
+    le.stage = MapInstallStage::Queued;
+    this->local_imports.push_back(std::move(le));
 }
 
 void BeatmapInstaller::cancel(i32 set_id) {
@@ -73,7 +101,7 @@ std::vector<BeatmapInstaller::EntryView> BeatmapInstaller::snapshot() const {
 void BeatmapInstaller::clear() { this->entries.clear(); }
 
 void BeatmapInstaller::update() {
-    if(this->entries.empty()) return;
+    if(this->entries.empty() && this->local_imports.empty()) return;
 
     const f64 now = engine->getTime();
 
@@ -109,7 +137,7 @@ void BeatmapInstaller::update() {
                 if(!db->isFinished() || db->isCancelled()) break;
 
                 const std::string mapset_path = fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id);
-                const BeatmapSet* set = db->addBeatmapSet(mapset_path, set_id);
+                auto [set, imported] = db->addBeatmapSet(mapset_path, set_id);
                 if(set == nullptr) {
                     e.stage = Failed;
                     e.finished_time = now;
@@ -117,7 +145,9 @@ void BeatmapInstaller::update() {
                 } else {
                     e.stage = Done;
                     e.finished_time = now;
-                    this->on_done(set_id, e, set);
+                    ui->getNotificationOverlay()->addToast(tformat("Downloaded beatmapset #{:d}", set_id),
+                                                           SUCCESS_TOAST);
+                    this->on_done(set, set_id, imported, e.auto_select);
                 }
                 break;
             }
@@ -125,6 +155,7 @@ void BeatmapInstaller::update() {
             case Done:
             case Failed:
             case None:
+            case Extracting:  // downloads never enter Extracting; that stage is local-import only
                 break;
         }
 
@@ -137,17 +168,115 @@ void BeatmapInstaller::update() {
             ++it;
         }
     }
+
+    // local .osz imports (drag-drop, file association, maps/ watcher). these have no set_id until the
+    // archive is cracked open, so they live here rather than in the set_id-keyed download map. nothing
+    // else mutates local_imports during this loop, so iterators stay valid.
+    for(auto it = this->local_imports.begin(); it != this->local_imports.end();) {
+        LocalEntry& le = *it;
+
+        switch(le.stage) {
+            using enum MapInstallStage;
+            case Queued: {
+                // read + decompress + extract on a worker so the main thread never blocks on it.
+                le.extract_future = Async::submit(
+                    [path = le.osz_path]() -> i32 {
+                        FixedSizeArray<u8> osz_data;
+                        {
+                            File osz(path);
+                            const uSz filesize = osz.getFileSize();
+                            osz_data = FixedSizeArray{osz.takeFileBuffer(), filesize};
+                            if(!osz.canRead() || !filesize || !osz_data.data()) return -1;
+                        }
+
+                        // fallback id: a leading number in the filename, e.g. "12345 Artist - Title.osz"
+                        i32 fallback_id = -1;
+                        std::string name = Environment::getFileNameFromFilePath(path);
+                        if(!name.empty() && std::isdigit(static_cast<unsigned char>(name[0]))) {
+                            if(!Parsing::parse(name, &fallback_id)) fallback_id = -1;
+                        }
+
+                        return Downloader::resolve_and_extract_osz(osz_data, name, fallback_id);
+                    },
+                    Lane::Background);
+                le.stage = Extracting;
+                break;
+            }
+
+            case Extracting: {
+                if(!le.extract_future.is_ready()) break;
+                le.set_id = le.extract_future.get();
+                if(le.set_id <= 0) {
+                    le.stage = Failed;
+                    le.finished_time = now;
+                    ui->getNotificationOverlay()->addToast(
+                        fmt::format("Failed to import {}", Environment::getFileNameFromFilePath(le.osz_path)),
+                        ERROR_TOAST);
+                } else {
+                    le.stage = Installing;
+                }
+                break;
+            }
+
+            case Installing: {
+                // same guard as downloads: don't import while the database is being (re)built.
+                // TODO: dedup
+                if(!db->isFinished() || db->isCancelled()) break;
+
+                const std::string mapset_path = fmt::format(NEOMOD_MAPS_PATH "/{}/", le.set_id);
+                auto [set, imported] = db->addBeatmapSet(mapset_path, le.set_id);
+                if(set == nullptr) {
+                    le.stage = Failed;
+                    le.finished_time = now;
+                    ui->getNotificationOverlay()->addToast(
+                        fmt::format("Failed to import {}", Environment::getFileNameFromFilePath(le.osz_path)),
+                        ERROR_TOAST);
+                } else {
+                    le.stage = Done;
+                    le.finished_time = now;
+                    if(le.delete_after) env->deleteFile(le.osz_path);
+                    this->on_done(set, le.set_id, imported, le.auto_select);
+                }
+                break;
+            }
+
+            case Downloading:
+            case Done:
+            case Failed:
+            case None:
+                break;
+        }
+
+        if(le.stage == MapInstallStage::Done ||
+           (le.stage == MapInstallStage::Failed && (now - le.finished_time) > FAILED_ENTRY_TTL_S)) {
+            it = this->local_imports.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
-void BeatmapInstaller::on_done(i32 set_id, const Entry& e, const BeatmapSet* set) {
-    debugLog("Finished installing beatmapset {:d}", set_id);
+void BeatmapInstaller::on_done(BeatmapSet* set, i32 set_id, bool added, bool auto_select) {
+    // we may have added a duplicate
+    debugLog("Finished installing beatmapset {:d}{:s}", set_id, !added ? " (duplicate)" : "");
+    if(added) {
+        ui->getSongBrowser()->addBeatmapSet(set);
+    }
 
-    ui->getNotificationOverlay()->addToast(tformat("Downloaded beatmapset #{:d}", set_id), SUCCESS_TOAST);
-
-    if(e.auto_select) {
+    if(auto_select) {
         const auto& diffs = set->getDifficulties();
         assert(!diffs.empty());  // if we successfully added it, we must have difficulties!
-        ui->getSongBrowser()->onDifficultySelected(diffs[0].get(), false);
+
+        // TODO: spaghetti
+        // (onDifficultySelected just plays music, i.e. we can call it when we are still in online beatmaps screen)
+        // otherwise actually select it
+        // ALSO TODO: if we are in songbrowser and importing a lot of maps, it will cause us to jump around...
+        // (existing issue)
+        if(ui->getActiveScreen() == ui->getSongBrowserBase()) {
+            ui->getSongBrowser()->selectBeatmapset(set);
+        } else {
+            ui->getSongBrowser()->onDifficultySelected(diffs[0].get(), false);
+        }
     }
 }
 

--- a/src/App/Neomod/BeatmapInstaller.cpp
+++ b/src/App/Neomod/BeatmapInstaller.cpp
@@ -58,9 +58,15 @@ void BeatmapInstaller::enqueue_local(std::string osz_path, bool auto_select, boo
 
     LocalEntry le;
     le.osz_path = std::move(osz_path);
-    le.auto_select = auto_select;
     le.delete_after = delete_after;
     le.stage = MapInstallStage::Queued;
+
+    // auto-select first enqueued map if we get > 1 at a time
+    // NOTE: this logic will work "incorrectly" if we ever try to enqueue a local beatmap to import with auto_select is false
+    // and the local_imports already has non-auto_select elements in it,
+    // but that currently never happens, and this is simpler than re-scanning it or adding more bookkeeping
+    le.auto_select = auto_select && this->local_imports.empty();
+
     this->local_imports.push_back(std::move(le));
 }
 
@@ -184,8 +190,7 @@ void BeatmapInstaller::update() {
                     le.stage = Failed;
                     le.finished_time = now;
                     ui->getNotificationOverlay()->addToast(
-                        fmt::format("Failed to import {}", Environment::getFileNameFromFilePath(le.osz_path)),
-                        ERROR_TOAST);
+                        tformat("Failed to import {}", Environment::getFileNameFromFilePath(le.osz_path)), ERROR_TOAST);
                 } else {
                     le.stage = Installing;
                 }
@@ -200,8 +205,7 @@ void BeatmapInstaller::update() {
                     le.stage = Failed;
                     le.finished_time = now;
                     ui->getNotificationOverlay()->addToast(
-                        fmt::format("Failed to import {}", Environment::getFileNameFromFilePath(le.osz_path)),
-                        ERROR_TOAST);
+                        tformat("Failed to import {}", Environment::getFileNameFromFilePath(le.osz_path)), ERROR_TOAST);
                 } else {
                     le.stage = Done;
                     le.finished_time = now;
@@ -250,8 +254,6 @@ void BeatmapInstaller::on_done(BeatmapSet* set, i32 set_id, bool added, bool aut
         // TODO: spaghetti
         // (onDifficultySelected just plays music, i.e. we can call it when we are still in online beatmaps screen)
         // otherwise actually select it
-        // ALSO TODO: if we are in songbrowser and importing a lot of maps, it will cause us to jump around...
-        // (existing issue)
         if(ui->getActiveScreen() == ui->getSongBrowserBase()) {
             ui->getSongBrowser()->selectBeatmapset(set);
         } else {

--- a/src/App/Neomod/BeatmapInstaller.h
+++ b/src/App/Neomod/BeatmapInstaller.h
@@ -95,6 +95,18 @@ class BeatmapInstaller final {
         f64 finished_time{0.0};
     };
 
+    // result of try_import(): set/imported are valid only when ready == true. ready == false means the
+    // db is mid-(re)build and the caller should retry next tick (addBeatmapSet would race the loader).
+    struct ImportResult {
+        BeatmapSet* set{nullptr};
+        bool imported{false};
+        bool ready{false};
+    };
+
+    // shared Installing-stage tail for downloads and local imports: imports the already-extracted
+    // maps/<set_id>/ folder once the db is idle.
+    ImportResult try_import(i32 set_id);
+
     void on_done(BeatmapSet* set, i32 set_id, bool added, bool auto_select);
     void on_failed(i32 set_id);
 

--- a/src/App/Neomod/BeatmapInstaller.h
+++ b/src/App/Neomod/BeatmapInstaller.h
@@ -60,6 +60,7 @@ class BeatmapInstaller final {
     // import a local .osz file (drag-drop, file association, maps/ watcher). the set id is unknown
     // until the archive is cracked open on a worker thread. delete_after removes the source file once
     // imported (used for the maps/ drop-zone, never for files the user passed in by path).
+    // NOTE: auto_select has some quirks you might want to read about if you set it to false (see enqueue_local function body)
     void enqueue_local(std::string osz_path, bool auto_select, bool delete_after);
 
     // aborts the in-flight transfer (if any) and drops the entry.

--- a/src/App/Neomod/BeatmapInstaller.h
+++ b/src/App/Neomod/BeatmapInstaller.h
@@ -4,6 +4,7 @@
 #include "noinclude.h"
 
 #include "types.h"
+#include "AsyncFuture.h"
 #include "DownloadHandle.h"
 #include "Hashing.h"
 
@@ -20,11 +21,13 @@ enum class MapInstallStage : u8 {
     Downloading = (1 << 2),
     Installing = (1 << 3),
     Done = (1 << 4),
-    Failed = (1 << 5)
+    Failed = (1 << 5),
+    Extracting = (1 << 6),  // local .osz imports only: decompress on a worker before Installing
 };
 
-// drives beatmapset download + extraction + database import as a single async unit,
-// keyed by set_id and decoupled from any UI element. ticked from Osu::update().
+// drives beatmapset import (downloaded sets and local .osz files) as a single async unit, decoupled
+// from any UI element. ticked from Osu::update(). downloads are keyed by set_id; local files have no
+// id until cracked open, so they ride a separate queue and resolve theirs on a worker thread.
 class BeatmapInstaller final {
     NOCOPY_NOMOVE(BeatmapInstaller)
    public:
@@ -54,6 +57,11 @@ class BeatmapInstaller final {
     // upgrades an entry queued earlier without one).
     void enqueue(i32 set_id, bool auto_select, std::string_view display_name = {});
 
+    // import a local .osz file (drag-drop, file association, maps/ watcher). the set id is unknown
+    // until the archive is cracked open on a worker thread. delete_after removes the source file once
+    // imported (used for the maps/ drop-zone, never for files the user passed in by path).
+    void enqueue_local(std::string osz_path, bool auto_select, bool delete_after);
+
     // aborts the in-flight transfer (if any) and drops the entry.
     void cancel(i32 set_id);
 
@@ -76,10 +84,22 @@ class BeatmapInstaller final {
         f64 finished_time{0.0};
     };
 
-    void on_done(i32 set_id, const Entry& e, const BeatmapSet* set);
+    // a local .osz import in flight. has no set_id until Extracting resolves it from the archive.
+    struct LocalEntry {
+        std::string osz_path;
+        Async::Future<i32> extract_future;  // resolved set_id (>0) on success, <= 0 on failure
+        i32 set_id{-1};
+        MapInstallStage stage{MapInstallStage::Queued};
+        bool auto_select{false};
+        bool delete_after{false};
+        f64 finished_time{0.0};
+    };
+
+    void on_done(BeatmapSet* set, i32 set_id, bool added, bool auto_select);
     void on_failed(i32 set_id);
 
     Hash::flat::map<i32, Entry> entries;
+    std::vector<LocalEntry> local_imports;
 
     // how long to keep Failed entries around so listings can render the red state
     static constexpr f64 FAILED_ENTRY_TTL_S = 60.0;

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -17,7 +17,6 @@
 #include "Downloader.h"
 #include "Engine.h"
 #include "File.h"
-#include "FixedSizeArray.h"
 #include "LegacyReplay.h"
 #include "NotificationOverlay.h"
 #include "AsyncPool.h"
@@ -575,7 +574,8 @@ std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::strin
     return {raw_mapset, true};
 }
 
-// TODO: duplication in BeatmapInstaller
+// shares the .osz read + extract path with BeatmapInstaller (Downloader::read_and_extract_osz); kept as
+// a separate loader-stage import because it runs before the installer and song browser exist.
 void Database::importLooseOsz() {
     // import any loose .osz files sitting in the maps/ drop-zone (dropped in while the game was closed).
     // runs on the loader thread before the song browser builds its buttons, so these maps are part of
@@ -596,25 +596,7 @@ void Database::importLooseOsz() {
 
         const std::string path = NEOMOD_MAPS_PATH "/" + oszs[i];
 
-        FixedSizeArray<u8> osz_data;
-        {
-            File osz(path);
-            const uSz filesize = osz.getFileSize();
-            osz_data = FixedSizeArray{osz.takeFileBuffer(), filesize};
-            if(!osz.canRead() || !filesize || !osz_data.data()) {
-                debugLog("Failed to read {}", path);
-                continue;
-            }
-        }
-
-        // fallback id: a leading number in the filename, e.g. "12345 Artist - Title.osz"
-        i32 fallback_id = -1;
-        std::string name = Environment::getFileNameFromFilePath(path);
-        if(!name.empty() && std::isdigit(static_cast<unsigned char>(name[0]))) {
-            if(!Parsing::parse(name, &fallback_id)) fallback_id = -1;
-        }
-
-        const i32 set_id = Downloader::resolve_and_extract_osz(osz_data, name, fallback_id);
+        const i32 set_id = Downloader::read_and_extract_osz(path);
         if(set_id > 0 && this->addBeatmapSet(fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id), set_id).first != nullptr) {
             env->deleteFile(path);
         } else {

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -491,7 +491,7 @@ void Database::save() {
 
 // NOTE: Should currently only be used for neomod beatmapsets! e.g. from maps/ folder
 //       See loadRawBeatmap()
-//       (unless is_peppy is spec{ified, false}, in which case we're loading a raw osu folder and not saving the things we loaded)
+//       (unless is_peppy is specified, in which case we're loading a raw osu folder and not saving the things we loaded)
 std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::string &beatmapFolderPath,
                                                                 i32 set_id_override, bool is_peppy) {
     std::unique_ptr<BeatmapSet> mapset = loadRawBeatmap(beatmapFolderPath, is_peppy);
@@ -501,6 +501,9 @@ std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::strin
 
     const i32 real_set_id = set_id_override != -1 ? set_id_override : mapset->iSetID;
 
+    // an existing set that already owns one of our diffs (matched by MD5 below); used to return the real
+    // owner if every diff turns out to be a duplicate.
+    BeatmapSet *dedup_parent = nullptr;
     {
         // deduplicate diffs
         // TODO: this will disallow adding a neomod beatmapset if we already have a peppy beatmapset that is the same (and vice versa)!
@@ -511,6 +514,7 @@ std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::strin
             if(!inserted) {
                 // update set id just in case we had an override, though
                 BeatmapDifficulty *diffparent = existingit->second->parentSet;
+                dedup_parent = diffparent;
                 if(const i32 old_set_id = diffparent->iSetID; old_set_id == -1 && real_set_id > 0) {
                     logIfCV(debug_db, "updating old set {} id {} -> {}", diffparent->getFolder(), old_set_id,
                             real_set_id);
@@ -534,19 +538,10 @@ std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::strin
         debugLog("WARNING: didn't add new mapset {} id {}, only had duplicate difficulties!", mapset->getFolder(),
                  real_set_id);
 
-        BeatmapSet *existing_mapset = nullptr;
-        for(const auto &set : this->beatmapsets) {
-            if(set->getSetID() == real_set_id) {
-                existing_mapset = set.get();
-            }
-        }
-
-        if(existing_mapset) {
-            return {existing_mapset, false};
-        } else {
-            assert(false);  // should be unreachable
-            return {};
-        }
+        // every diff was a duplicate, so dedup_parent points at the existing set that owns them. its set
+        // id may differ from real_set_id (e.g. the same map present as both a peppy and a neomod set, per
+        // the TODO above), which is why we return the matched parent rather than re-searching by id.
+        return {dedup_parent, false};
     }
 
     // Some beatmaps don't provide beatmap/beatmapset IDs in the .osu files

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -14,8 +14,10 @@
 #include "Database.h"
 #include "DatabaseBeatmap.h"
 #include "DirectoryWatcher.h"
+#include "Downloader.h"
 #include "Engine.h"
 #include "File.h"
+#include "FixedSizeArray.h"
 #include "LegacyReplay.h"
 #include "NotificationOverlay.h"
 #include "AsyncPool.h"
@@ -35,6 +37,7 @@
 #include "fmt/chrono.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cstring>
 #include <utility>
 
@@ -284,6 +287,12 @@ void Database::startLoader() {
                 this->loadMaps(this->database_files[NEOMOD_MAPS], this->database_files[STABLE_MAPS]);
                 if(tok.stop_requested()) goto done;
 
+                // extract + import any loose .osz files dropped into maps/ before handing off to the
+                // song browser, so they're part of the initial listing.
+                // TODO: add to progress indicator
+                this->importLooseOsz();
+                if(tok.stop_requested()) goto done;
+
                 // loaded after raw load otherwise
                 if(!this->needs_raw_load) {
                     Collections::load_all(this->database_files[MCNEOMOD_COLLECTIONS],
@@ -482,10 +491,11 @@ void Database::save() {
 
 // NOTE: Should currently only be used for neomod beatmapsets! e.g. from maps/ folder
 //       See loadRawBeatmap()
-//       (unless is_peppy is specified, in which case we're loading a raw osu folder and not saving the things we loaded)
-const BeatmapSet *Database::addBeatmapSet(const std::string &beatmapFolderPath, i32 set_id_override, bool is_peppy) {
-    std::unique_ptr<BeatmapSet> mapset = this->loadRawBeatmap(beatmapFolderPath, is_peppy);
-    if(mapset == nullptr) return nullptr;
+//       (unless is_peppy is spec{ified, false}, in which case we're loading a raw osu folder and not saving the things we loaded)
+std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::string &beatmapFolderPath,
+                                                                i32 set_id_override, bool is_peppy) {
+    std::unique_ptr<BeatmapSet> mapset = loadRawBeatmap(beatmapFolderPath, is_peppy);
+    if(mapset == nullptr) return {};
 
     BeatmapSet *raw_mapset = mapset.get();
 
@@ -523,11 +533,19 @@ const BeatmapSet *Database::addBeatmapSet(const std::string &beatmapFolderPath, 
     if(mapset->difficulties->empty()) {
         debugLog("WARNING: didn't add new mapset {} id {}, only had duplicate difficulties!", mapset->getFolder(),
                  real_set_id);
-        if(const auto *existing_mapset = this->getBeatmapSet(real_set_id)) {
-            return existing_mapset;
+
+        BeatmapSet *existing_mapset = nullptr;
+        for(const auto &set : this->beatmapsets) {
+            if(set->getSetID() == real_set_id) {
+                existing_mapset = set.get();
+            }
+        }
+
+        if(existing_mapset) {
+            return {existing_mapset, false};
         } else {
             assert(false);  // should be unreachable
-            return nullptr;
+            return {};
         }
     }
 
@@ -542,9 +560,10 @@ const BeatmapSet *Database::addBeatmapSet(const std::string &beatmapFolderPath, 
 
     this->beatmapsets.push_back(std::move(mapset));
 
-    // only notify songbrowser if loading is done (it rebuilds from beatmapsets in onDatabaseLoadingFinished)
+    // post-load imports still need diffcalc + loudness kicked off here
+    // during the initial load the browser rebuilds from
+    // beatmapsets in onDatabaseLoadingFinished, so there's nothing to do.
     if(this->isFinished()) {
-        ui->getSongBrowser()->addBeatmapSet(raw_mapset);
         this->batch_diffcalc_pending = true;  // picked up by SongBrowser::update
 
         // post-DB-load imports never made it into loudness_to_calc, so kick off priority
@@ -558,7 +577,60 @@ const BeatmapSet *Database::addBeatmapSet(const std::string &beatmapFolderPath, 
         this->saveMaps();
     }
 
-    return raw_mapset;
+    return {raw_mapset, true};
+}
+
+// TODO: duplication in BeatmapInstaller
+void Database::importLooseOsz() {
+    // import any loose .osz files sitting in the maps/ drop-zone (dropped in while the game was closed).
+    // runs on the loader thread before the song browser builds its buttons, so these maps are part of
+    // the initial listing. isFinished() is still false here, so addBeatmapSet won't notify the
+    // not-yet-built song browser, and appending to beatmapsets is safe (same thread as loadMaps).
+    std::vector<std::string> files = env->getFilesInFolder(NEOMOD_MAPS_PATH "/");
+
+    std::vector<std::string> oszs;
+    for(auto &file : files) {
+        if(env->getFileExtensionFromFilePath(file) == "osz") oszs.push_back(std::move(file));
+    }
+    if(oszs.empty()) return;
+
+    debugLog("Importing {} loose .osz file(s) from {}", oszs.size(), NEOMOD_MAPS_PATH "/");
+
+    for(uSz i = 0; i < oszs.size(); i++) {
+        if(this->isCancelled()) return;  // cancellation point
+
+        const std::string path = NEOMOD_MAPS_PATH "/" + oszs[i];
+
+        FixedSizeArray<u8> osz_data;
+        {
+            File osz(path);
+            const uSz filesize = osz.getFileSize();
+            osz_data = FixedSizeArray{osz.takeFileBuffer(), filesize};
+            if(!osz.canRead() || !filesize || !osz_data.data()) {
+                debugLog("Failed to read {}", path);
+                continue;
+            }
+        }
+
+        // fallback id: a leading number in the filename, e.g. "12345 Artist - Title.osz"
+        i32 fallback_id = -1;
+        std::string name = Environment::getFileNameFromFilePath(path);
+        if(!name.empty() && std::isdigit(static_cast<unsigned char>(name[0]))) {
+            if(!Parsing::parse(name, &fallback_id)) fallback_id = -1;
+        }
+
+        const i32 set_id = Downloader::resolve_and_extract_osz(osz_data, name, fallback_id);
+        if(set_id > 0 && this->addBeatmapSet(fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id), set_id).first != nullptr) {
+            env->deleteFile(path);
+        } else {
+            debugLog("Failed to import loose .osz {}", path);
+        }
+
+        // nudge the loading bar forward through the import tail (loadMaps leaves us near 0.99); stays
+        // below 1.0 so the loading overlay keeps the song browser hidden until every import is done.
+        // (FIXME: HACK)
+        this->loading_progress = static_cast<f32>(0.99 + 0.0099 * (f64)(i + 1) / (f64)oszs.size());
+    }
 }
 
 bool Database::addScore(const FinishedScore &score) {

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -252,6 +252,9 @@ void Database::startLoader() {
 
     this->is_first_load = true;
 
+    this->import_done.store(0, std::memory_order_release);
+    this->import_total.store(0, std::memory_order_release);
+
     this->loudness_to_calc.clear();
     {
         Sync::unique_lock lock(this->beatmap_difficulties_mtx);
@@ -288,7 +291,6 @@ void Database::startLoader() {
 
                 // extract + import any loose .osz files dropped into maps/ before handing off to the
                 // song browser, so they're part of the initial listing.
-                // TODO: add to progress indicator
                 this->importLooseOsz();
                 if(tok.stop_requested()) goto done;
 
@@ -603,8 +605,14 @@ void Database::importLooseOsz() {
 
     debugLog("Importing {} loose .osz file(s) from {}", oszs.size(), NEOMOD_MAPS_PATH "/");
 
+    // the .osz aren't in loadMaps' byte budget, so the percentage stays pinned near 0.99 throughout
+    // this loop; the import count surfaced via getLoadingMessage() is the user's actual progress signal.
+    this->import_total.store(static_cast<u32>(oszs.size()), std::memory_order_release);
+
     for(uSz i = 0; i < oszs.size(); i++) {
         if(this->isCancelled()) return;  // cancellation point
+
+        this->import_done.store(static_cast<u32>(i + 1), std::memory_order_release);
 
         const std::string path = NEOMOD_MAPS_PATH "/" + oszs[i];
 
@@ -614,11 +622,6 @@ void Database::importLooseOsz() {
         } else {
             debugLog("Failed to import loose .osz {}", path);
         }
-
-        // nudge the loading bar forward through the import tail (loadMaps leaves us near 0.99); stays
-        // below 1.0 so the loading overlay keeps the song browser hidden until every import is done.
-        // (FIXME: HACK)
-        this->loading_progress = static_cast<f32>(0.99 + 0.0099 * (f64)(i + 1) / (f64)oszs.size());
     }
 }
 

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -606,22 +606,42 @@ void Database::importLooseOsz() {
     debugLog("Importing {} loose .osz file(s) from {}", oszs.size(), NEOMOD_MAPS_PATH "/");
 
     // the .osz aren't in loadMaps' byte budget, so the percentage stays pinned near 0.99 throughout
-    // this loop; the import count surfaced via getLoadingMessage() is the user's actual progress signal.
+    // this loop; the import count surfaced via getImportDone()/getImportTotal() is the user's actual
+    // progress signal.
     this->import_total.store(static_cast<u32>(oszs.size()), std::memory_order_release);
 
+    // extraction (read + decompress + write) is ~99% of per-map cost and independent per file, so fan it
+    // out across the async pool while addBeatmapSet stays serial on this loader thread (it appends to
+    // beatmapsets / loudness_to_calc, which mustn't be touched concurrently). a bounded sliding window
+    // keeps at most window_size extractions in flight, so a huge drop can't pile up extracted folders on
+    // disk faster than the imports that delete each source .osz.
+    // (this loader is itself a pool task, but blocking on these sub-tasks is deadlock-free: the pool has
+    // >= 2 threads, fg threads work-steal bg tasks, and read_and_extract_osz never re-enters the pool.)
+    const uSz window_size = std::min<uSz>(std::clamp<uSz>(AsyncPool::get().thread_count(), 4, 16), oszs.size());
+
+    auto submit_extract = [](const std::string &osz_name) {
+        return Async::submit(
+            [path = NEOMOD_MAPS_PATH "/" + osz_name]() -> i32 { return Downloader::read_and_extract_osz(path); },
+            Lane::Background);
+    };
+
+    std::vector<Async::Future<i32>> window(window_size);
+    for(uSz i = 0; i < window_size; i++) window[i] = submit_extract(oszs[i]);
+
     for(uSz i = 0; i < oszs.size(); i++) {
-        if(this->isCancelled()) return;  // cancellation point
+        if(this->isCancelled()) return;  // abandons in-flight extracts; harmless, re-imported next run
 
-        this->import_done.store(static_cast<u32>(i + 1), std::memory_order_release);
-
+        // window[i % window_size] holds oszs[i]'s extraction (primed above, then refilled in order)
+        const i32 set_id = window[i % window_size].get();
         const std::string path = NEOMOD_MAPS_PATH "/" + oszs[i];
-
-        const i32 set_id = Downloader::read_and_extract_osz(path);
         if(set_id > 0 && this->addBeatmapSet(fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id), set_id).first != nullptr) {
             env->deleteFile(path);
         } else {
             debugLog("Failed to import loose .osz {}", path);
         }
+        this->import_done.store(static_cast<u32>(i + 1), std::memory_order_release);
+
+        if(const uSz next = i + window_size; next < oszs.size()) window[i % window_size] = submit_extract(oszs[next]);
     }
 }
 

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -493,8 +493,8 @@ void Database::save() {
 // NOTE: Should currently only be used for neomod beatmapsets! e.g. from maps/ folder
 //       See loadRawBeatmap()
 //       (unless is_peppy is specified, in which case we're loading a raw osu folder and not saving the things we loaded)
-std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::string &beatmapFolderPath,
-                                                                i32 set_id_override, bool is_peppy) {
+std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(std::string_view beatmapFolderPath, i32 set_id_override,
+                                                                bool is_peppy) {
     std::unique_ptr<BeatmapSet> mapset = loadRawBeatmap(beatmapFolderPath, is_peppy);
     if(mapset == nullptr) return {};
 
@@ -595,15 +595,14 @@ void Database::importLooseOsz() {
     // runs on the loader thread before the song browser builds its buttons, so these maps are part of
     // the initial listing. isFinished() is still false here, so addBeatmapSet won't notify the
     // not-yet-built song browser, and appending to beatmapsets is safe (same thread as loadMaps).
-    std::vector<std::string> files = env->getFilesInFolder(NEOMOD_MAPS_PATH "/");
 
     std::vector<std::string> oszs;
-    for(auto &file : files) {
-        if(env->getFileExtensionFromFilePath(file) == "osz") oszs.push_back(std::move(file));
+    for(auto &file : env->getFilesInFolder(NEOMOD_MAPS_PATH "/")) {
+        if(file.ends_with(".osz")) oszs.push_back(std::move(file));
     }
     if(oszs.empty()) return;
 
-    debugLog("Importing {} loose .osz file(s) from {}", oszs.size(), NEOMOD_MAPS_PATH "/");
+    debugLog("Importing {:d} loose .osz file(s) from {}", oszs.size(), NEOMOD_MAPS_PATH "/");
 
     // the .osz aren't in loadMaps' byte budget, so the percentage stays pinned near 0.99 throughout
     // this loop; the import count surfaced via getImportDone()/getImportTotal() is the user's actual
@@ -617,7 +616,7 @@ void Database::importLooseOsz() {
     // disk faster than the imports that delete each source .osz.
     // (this loader is itself a pool task, but blocking on these sub-tasks is deadlock-free: the pool has
     // >= 2 threads, fg threads work-steal bg tasks, and read_and_extract_osz never re-enters the pool.)
-    const uSz window_size = std::min<uSz>(std::clamp<uSz>(AsyncPool::get().thread_count(), 4, 16), oszs.size());
+    const uSz window_size = std::min<uSz>(std::clamp<uSz>(Async::get_thread_count(), 4, 16), oszs.size());
 
     auto submit_extract = [](const std::string &osz_name) {
         return Async::submit(
@@ -2700,26 +2699,26 @@ void Database::saveScores() {
     debugLog("Saved {:d} scores in {:f} seconds.", nb_scores, (Timing::getTimeReal() - startTime));
 }
 
-std::unique_ptr<BeatmapSet> Database::loadRawBeatmap(const std::string &beatmapPath, bool is_peppy) {
+std::unique_ptr<BeatmapSet> Database::loadRawBeatmap(std::string_view beatmapPathUnsanitized, bool is_peppy) {
+    // this should never happen but guard against it anyways
+    // (lots of things expect beatmapPath to end with a path separator, if it doesn't, things would blow up in weird ways)
+    const std::string beatmapPath{beatmapPathUnsanitized.ends_with('/') ? beatmapPathUnsanitized
+                                                                        : fmt::format("{:s}/", beatmapPathUnsanitized)};
     logIfCV(debug_db, "beatmap path: {:s}", beatmapPath);
-
-    // try loading all diffs
-    DatabaseBeatmap::LoadError lastError;
 
     auto diffs = std::make_unique<DiffContainer>();
 
+    using enum DatabaseBeatmap::BeatmapType;
+    auto difficultyType = is_peppy ? PEPPY_DIFFICULTY : NEOMOD_DIFFICULTY;
+
+    // try loading all diffs
+    DatabaseBeatmap::LoadError lastError;
     std::vector<std::string> beatmapFiles = env->getFilesInFolder(beatmapPath);
-
     for(const auto &beatmapFile : beatmapFiles) {
-        std::string ext = env->getFileExtensionFromFilePath(beatmapFile);
-        if(ext.compare("osu") != 0) continue;
+        if(!beatmapFile.ends_with(".osu")) continue;
 
-        std::string fullFilePath = beatmapPath;
-        fullFilePath.append(beatmapFile);
-
-        auto map = std::make_unique<BeatmapDifficulty>(fullFilePath, beatmapPath,
-                                                       is_peppy ? DatabaseBeatmap::BeatmapType::PEPPY_DIFFICULTY
-                                                                : DatabaseBeatmap::BeatmapType::NEOMOD_DIFFICULTY);
+        const std::string fullFilePath = fmt::format("{:s}{:s}", beatmapPath, beatmapFile);
+        auto map = std::make_unique<BeatmapDifficulty>(fullFilePath, beatmapPath, difficultyType);
         auto res = map->loadMetadata();
         if(!res.error.errc) {
             diffs->push_back(std::move(map));
@@ -2731,9 +2730,8 @@ std::unique_ptr<BeatmapSet> Database::loadRawBeatmap(const std::string &beatmapP
 
     std::unique_ptr<BeatmapSet> set{nullptr};
     if(diffs && !diffs->empty()) {
-        set =
-            std::make_unique<BeatmapSet>(std::move(diffs), is_peppy ? DatabaseBeatmap::BeatmapType::PEPPY_BEATMAPSET
-                                                                    : DatabaseBeatmap::BeatmapType::NEOMOD_BEATMAPSET);
+        auto setType = is_peppy ? PEPPY_BEATMAPSET : NEOMOD_BEATMAPSET;
+        set = std::make_unique<BeatmapSet>(std::move(diffs), setType);
     }
 
     if(!set && lastError.errc) {

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -554,21 +554,33 @@ std::pair<BeatmapSet *, bool /*added*/> Database::addBeatmapSet(const std::strin
 
     this->beatmapsets.push_back(std::move(mapset));
 
-    // post-load imports still need diffcalc + loudness kicked off here
-    // during the initial load the browser rebuilds from
-    // beatmapsets in onDatabaseLoadingFinished, so there's nothing to do.
+    // kick off loudness for the freshly added diffs. BatchDiffCalc finds maps needing diffcalc
+    // dynamically, but VolNormalization::start_calc only ever processes the explicit loudness_to_calc
+    // vector, so imports have to funnel their diffs into it themselves or never get calculated.
     if(this->isFinished()) {
         this->batch_diffcalc_pending = true;  // picked up by SongBrowser::update
 
-        // post-DB-load imports never made it into loudness_to_calc, so kick off priority
-        // requests now so the maps have correct loudness by the time the user previews them.
+        // post-load import: the batch loudness pass already ran, so request priority calc now so the
+        // map has correct loudness by the time the user previews it.
         for(const auto &diff : raw_mapset->getDifficulties()) {
             VolNormalization::request_priority(diff.get());
         }
-    }
 
-    if(cv::maps_save_immediately.getBool()) {
-        this->saveMaps();
+        // saveMaps already guards itself by this->isFinished(), but putting it here for clarity anyways
+        // NOTE: this should be removed, only done as a "hack" to prevent corrupt database/folder state
+        // (which loading from raw folders would fix in a better way)
+        // (mainly relevant on WASM where it's more likely that the page might be unloaded before we successfully saved on shutdown)
+        if(cv::maps_save_immediately.getBool()) {
+            this->saveMaps();
+        }
+    } else {
+        // pre-finish import (raw load / loose .osz on the loader thread): the priority worker won't run
+        // until after load and these never pass through loadMaps' db-read path (which is what normally
+        // populates loudness_to_calc), so add them for the batch start_calc at load completion. without
+        // this their loudness stays 0 until a restart re-reads them from the db.
+        for(const auto &diff : raw_mapset->getDifficulties()) {
+            this->loudness_to_calc.push_back(diff.get());
+        }
     }
 
     return {raw_mapset, true};

--- a/src/App/Neomod/Database.cpp
+++ b/src/App/Neomod/Database.cpp
@@ -861,7 +861,7 @@ Database::PlayerStats Database::calculatePlayerStats(std::string_view playerName
     for(uSz i = 0; i < ps.ppScores.size(); i++) {
         const float weight = getWeightForIndex(ps.ppScores.size() - 1 - i);
 
-        pp += ps.ppScores[i]->get_pp() * weight;
+        pp += (f32)ps.ppScores[i]->get_pp() * weight;
         acc += LiveScore::calculateAccuracy(ps.ppScores[i]->num300s, ps.ppScores[i]->num100s, ps.ppScores[i]->num50s,
                                             ps.ppScores[i]->numMisses) *
                weight;
@@ -887,8 +887,8 @@ Database::PlayerStats Database::calculatePlayerStats(std::string_view playerName
 
         if(requiredScoreForNextLevel > requiredScoreForCurrentLevel)
             this->prevPlayerStats.percentToNextLevel =
-                (double)(ps.totalScore - requiredScoreForCurrentLevel) /
-                (double)(requiredScoreForNextLevel - requiredScoreForCurrentLevel);
+                (f32)((double)(ps.totalScore - requiredScoreForCurrentLevel) /
+                      (double)(requiredScoreForNextLevel - requiredScoreForCurrentLevel));
     }
 
     this->prevPlayerStats.totalScore = ps.totalScore;
@@ -896,17 +896,17 @@ Database::PlayerStats Database::calculatePlayerStats(std::string_view playerName
     return this->prevPlayerStats;
 }
 
-float Database::getWeightForIndex(int i) { return std::pow(0.95f, (f32)i); }
+float Database::getWeightForIndex(uSz i) { return std::pow(0.95f, (f32)i); }
 
 float Database::getBonusPPForNumScores(size_t numScores) {
-    return (417.0 - 1.0 / 3.0) * (1.0 - pow(0.995, std::min(1000.0, (f64)numScores)));
+    return (417.0f - 1.0f / 3.0f) * (f32)(1.0 - pow(0.995, std::min(1000.0, (f64)numScores)));
 }
 
 u64 Database::getRequiredScoreForLevel(int level) {
     // https://zxq.co/ripple/ocl/src/branch/master/level.go
     if(level <= 100) {
         if(level > 1)
-            return (u64)std::floor(5000 / 3 * (4 * pow(level, 3) - 3 * pow(level, 2) - level) +
+            return (u64)std::floor(5000. / 3 * (4 * pow(level, 3) - 3 * pow(level, 2) - level) +
                                    std::floor(1.25 * pow(1.8, (double)(level - 60))));
 
         return 1;
@@ -1117,7 +1117,7 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
 
                 u32 progress_bytes = this->bytes_processed + neomod_maps.total_pos;
                 f64 progress_float = (f64)progress_bytes / (f64)this->total_bytes;
-                this->loading_progress = std::clamp(progress_float, 0.01, 0.99);
+                this->loading_progress = (f32)std::clamp(progress_float, 0.01, 0.99);
 
                 i32 set_id = neomod_maps.read<i32>();
                 u16 nb_diffs = neomod_maps.read<u16>();
@@ -1209,7 +1209,7 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                     f32 fCS = neomod_maps.read<f32>();
                     f32 fHP = neomod_maps.read<f32>();
                     f32 fOD = neomod_maps.read<f32>();
-                    f64 fSliderMultiplier = neomod_maps.read<f64>();
+                    f64 fSliderMultiplier = neomod_maps.read<f64>();  // TODO: store as float?
                     u32 iPreviewTime = neomod_maps.read<u32>();
                     const i64 maybe_dotnettime = neomod_maps.read<i64>();
                     i64 last_modification_time = maybe_dotnettime;
@@ -1225,7 +1225,7 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                     u16 iNumCircles = neomod_maps.read<u16>();
                     u16 iNumSliders = neomod_maps.read<u16>();
                     u16 iNumSpinners = neomod_maps.read<u16>();
-                    f64 fStarsNomod = neomod_maps.read<f64>();
+                    f64 fStarsNomod = neomod_maps.read<f64>();  // TODO: store as float?
 
                     i32 iMinBPM{-1}, iMaxBPM{-1}, iMostCommonBPM{-1};
                     if(version >= 20251209) {  // prior versions had a rounding bug, force recalc
@@ -1337,15 +1337,15 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                     diff->fCS = fCS;
                     diff->fHP = fHP;
                     diff->fOD = fOD;
-                    diff->fSliderMultiplier = fSliderMultiplier;
-                    diff->iPreviewTime = iPreviewTime;
+                    diff->fSliderMultiplier = (f32)fSliderMultiplier;
+                    diff->iPreviewTime = (i32)iPreviewTime;
                     diff->last_modification_time = last_modification_time;
                     diff->iLocalOffset = iLocalOffset;
                     diff->iOnlineOffset = iOnlineOffset;
                     diff->iNumCircles = iNumCircles;
                     diff->iNumSliders = iNumSliders;
                     diff->iNumSpinners = iNumSpinners;
-                    diff->fStarsNomod = fStarsNomod;
+                    diff->fStarsNomod = (f32)fStarsNomod;
 
                     diff->iMinBPM = iMinBPM;
                     diff->iMaxBPM = iMaxBPM;
@@ -1506,7 +1506,7 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                 // update progress (another thread checks if progress >= 1.f to know when we're done)
                 u32 progress_bytes = this->bytes_processed + dbr.total_pos;
                 f64 progress_float = (f64)progress_bytes / (f64)this->total_bytes;
-                this->loading_progress = std::clamp(progress_float, 0.01, 0.99);
+                this->loading_progress = (f32)std::clamp(progress_float, 0.01, 0.99);
 
                 // NOTE: This is documented wrongly in many places.
                 //       This int was added in 20160408 and removed in 20191106
@@ -1556,6 +1556,7 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                 const i64 last_modification_time =
                     (modification_time_dotnet_ticks - LegacyReplay::UNIX_EPOCH_TICKS) / LegacyReplay::TICKS_PER_SECOND;
 
+                // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
                 f32 AR, CS, HP, OD;
                 if(osu_db_version < 20140609) {
                     AR = dbr.read<u8>();
@@ -1613,9 +1614,10 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                 }
 
                 /*unsigned int drainTime = */ dbr.skip<u32>();  // seconds
-                int duration = dbr.read<u32>();                 // milliseconds
+                int duration = (int)dbr.read<u32>();            // milliseconds
                 duration = duration >= 0 ? duration : 0;        // sanity clamp
-                int preview_time = dbr.read<u32>();
+                int preview_time = (int)dbr.read<u32>();
+                preview_time = preview_time >= 0 ? preview_time : 0;  // sanity clamp
 
                 BPMInfo bpm;
                 u32 nb_timing_points = dbr.read<u32>();
@@ -1627,7 +1629,8 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                     bpm.most_common = override_.avg_bpm;
                 } else if(nb_timing_points > 0) {
                     timing_points_buffer.resize(nb_timing_points);
-                    if(dbr.read_bytes((u8 *)timing_points_buffer.data(), sizeof(DB_TIMINGPOINT) * nb_timing_points) !=
+                    if(dbr.read_bytes(reinterpret_cast<u8 *>(timing_points_buffer.data()),
+                                      sizeof(DB_TIMINGPOINT) * nb_timing_points) !=
                        sizeof(DB_TIMINGPOINT) * nb_timing_points) {
                         debugLog("WARNING: failed to read timing points from beatmap {:d} !", (i + 1));
                     } else {
@@ -1646,7 +1649,7 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                 /*unsigned char ctbGrade = */ dbr.skip<u8>();
                 /*unsigned char maniaGrade = */ dbr.skip<u8>();
 
-                u16 offset_local = dbr.read<u16>();
+                i16 offset_local = dbr.read<i16>();
                 f32 stack_leniency = dbr.read<f32>();
                 u8 mode = dbr.read<u8>();
 
@@ -1655,7 +1658,7 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                 SString::trim_inplace(song_source);
                 SString::trim_inplace(song_tags);
 
-                u16 offset_online = dbr.read<u16>();
+                i16 offset_online = dbr.read<i16>();
                 dbr.skip_string();  // song title font
                 /*bool unplayed = */ dbr.skip<u8>();
                 /*i64 lastTimePlayed = */ dbr.skip<u64>();
@@ -1754,7 +1757,8 @@ void Database::loadMaps(std::string_view neomod_maps_path, std::string_view pepp
                     map->fCS = CS;
                     map->fHP = HP;
                     map->fOD = OD;
-                    map->fSliderMultiplier = slider_multiplier;
+                    // is downcasting actually safe here...? why is this even stored as a double in osu!.db anyways
+                    map->fSliderMultiplier = (f32)slider_multiplier;
 
                     // map->sBackgroundImageFileName = "";
 
@@ -1944,7 +1948,7 @@ void Database::saveMaps() {
             maps.write<i32>(diff->iID);
             maps.write_string(diff->getTitle());
             maps.write_string(diff->getAudioFileName());
-            maps.write<i32>(diff->iLengthMS);
+            maps.write<i32>((i32)diff->iLengthMS);  // TODO: weird casting
             maps.write<f32>(diff->fStackLeniency);
             maps.write_string(diff->getArtist());
             maps.write_string(diff->getCreator());
@@ -2136,8 +2140,8 @@ void Database::loadScores(std::string_view dbPath) {
     }
 
     u32 nb_neomod_scores = 0;
-    u8 magic_bytes[6] = {0};
-    if(dbr.read_bytes(magic_bytes, 5) != 5 || memcmp(magic_bytes, "NEOSC", 5) != 0) {
+    std::array<u8, 6> magic_bytes{};
+    if(dbr.read_bytes(magic_bytes.data(), 5) != 5 || memcmp(magic_bytes.data(), "NEOSC", 5) != 0) {
         ui->getNotificationOverlay()->addToast("Failed to load " PACKAGE_NAME "_scores.db!", ERROR_TOAST);
         this->bytes_processed += dbr.total_size;
         return;
@@ -2201,9 +2205,10 @@ void Database::loadScores(std::string_view dbPath) {
             sc.unstableRate = dbr.read<f32>();
             sc.hitErrorAvgMin = dbr.read<f32>();
             sc.hitErrorAvgMax = dbr.read<f32>();
-            sc.maxPossibleCombo = dbr.read<u32>();
-            sc.numHitObjects = dbr.read<u32>();
-            sc.numCircles = dbr.read<u32>();
+            // TODO: look into casts...
+            sc.maxPossibleCombo = (int)dbr.read<u32>();
+            sc.numHitObjects = (int)dbr.read<u32>();
+            sc.numCircles = (int)dbr.read<u32>();
 
             sc.beatmap_hash = beatmap_hash;
 
@@ -2213,7 +2218,7 @@ void Database::loadScores(std::string_view dbPath) {
 
         u32 progress_bytes = this->bytes_processed + dbr.total_pos;
         f64 progress_float = (f64)progress_bytes / (f64)this->total_bytes;
-        this->loading_progress = std::clamp(progress_float, 0.01, 0.99);
+        this->loading_progress = (f32)std::clamp(progress_float, 0.01, 0.99);
     }
 
     if(nb_neomod_scores != nb_scores) {
@@ -2245,7 +2250,7 @@ void Database::loadOldMcNeomodScores(std::string_view dbPath) {
         for(u32 b = 0; b < nb_beatmaps; b++) {
             u32 progress_bytes = this->bytes_processed + dbr.total_pos;
             f64 progress_float = (f64)progress_bytes / (f64)this->total_bytes;
-            this->loading_progress = std::clamp(progress_float, 0.01, 0.99);
+            this->loading_progress = (f32)std::clamp(progress_float, 0.01, 0.99);
             MD5Hash md5hash;
             (void)dbr.read_hash_chars(md5hash);  // TODO: validate
             u32 nb_scores = dbr.read<u32>();
@@ -2281,9 +2286,10 @@ void Database::loadOldMcNeomodScores(std::string_view dbPath) {
                 sc.mods.ar_override = dbr.read<f32>();
                 sc.mods.od_override = dbr.read<f32>();
                 sc.mods.hp_override = dbr.read<f32>();
-                sc.maxPossibleCombo = dbr.read<u32>();
-                sc.numHitObjects = dbr.read<u32>();
-                sc.numCircles = dbr.read<u32>();
+                // TODO: look into casts...
+                sc.maxPossibleCombo = (i32)dbr.read<u32>();
+                sc.numHitObjects = (i32)dbr.read<u32>();
+                sc.numCircles = (i32)dbr.read<u32>();
                 sc.bancho_score_id = dbr.read<u32>();
                 sc.client = PACKAGE_NAME "-win64-release-35.10";  // we don't know the actual version
                 dbr.read_string(sc.server);
@@ -2340,7 +2346,7 @@ void Database::loadOldMcNeomodScores(std::string_view dbPath) {
         for(int b = 0; b < numBeatmaps; b++) {
             u32 progress_bytes = this->bytes_processed + dbr.total_pos;
             f64 progress_float = (f64)progress_bytes / (f64)this->total_bytes;
-            this->loading_progress = std::clamp(progress_float, 0.01, 0.99);
+            this->loading_progress = (f32)std::clamp(progress_float, 0.01, 0.99);
 
             const std::string md5hash_str = dbr.read_string();
             if(md5hash_str.length() < 32) {
@@ -2521,7 +2527,7 @@ void Database::loadPeppyScores(std::string_view dbPath) {
 
     debugLog("osu!stable scores.db: version = {:d}, nb_beatmaps = {:d}", db_version, nb_beatmaps);
 
-    char client_str[15] = "peppy-YYYYMMDD";
+    std::array<char, 15> client_str{"peppy-YYYYMMDD"};
     for(u32 b = 0; b < nb_beatmaps; b++) {
         const std::string md5hash_str = dbr.read_string();
         if(md5hash_str.length() < 32) {
@@ -2543,8 +2549,8 @@ void Database::loadPeppyScores(std::string_view dbPath) {
             u8 gamemode = dbr.read<u8>();
 
             u32 score_version = dbr.read<u32>();
-            snprintf(client_str, 14, "peppy-%d", score_version);
-            sc.client = client_str;
+            snprintf(client_str.data(), 14, "peppy-%d", score_version);
+            sc.client = std::string_view{client_str};
 
             sc.server = "ppy.sh";
             dbr.skip_string();  // beatmap hash (already have it)
@@ -2601,7 +2607,7 @@ void Database::loadPeppyScores(std::string_view dbPath) {
 
         u32 progress_bytes = this->bytes_processed + dbr.total_pos;
         f64 progress_float = (f64)progress_bytes / (f64)this->total_bytes;
-        this->loading_progress = std::clamp(progress_float, 0.01, 0.99);
+        this->loading_progress = (f32)std::clamp(progress_float, 0.01, 0.99);
     }
 
     debugLog("Loaded {:d} osu!stable scores", nb_imported);
@@ -2626,7 +2632,7 @@ void Database::saveScores() {
         return;
     }
 
-    dbr.write_bytes((u8 *)"NEOSC", 5);
+    dbr.write_bytes(reinterpret_cast<const u8 *>("NEOSC"), 5);
     dbr.write<u32>(NEOMOD_SCORE_DB_VERSION);
 
     u32 nb_beatmaps = 0;

--- a/src/App/Neomod/Database.h
+++ b/src/App/Neomod/Database.h
@@ -93,8 +93,8 @@ class Database final {
     void cancel();
     void save();
 
-    std::pair<BeatmapSet *, bool /*added*/> addBeatmapSet(const std::string &beatmapFolderPath,
-                                                          i32 set_id_override = -1, bool is_peppy = false);
+    std::pair<BeatmapSet *, bool /*added*/> addBeatmapSet(std::string_view beatmapFolderPath, i32 set_id_override = -1,
+                                                          bool is_peppy = false);
 
     // returns true if adding succeeded
     bool addScore(const FinishedScore &score);
@@ -137,9 +137,9 @@ class Database final {
     static std::string getOsuSongsFolder();
 
     // only used for raw loading without db
-    static std::unique_ptr<BeatmapSet> loadRawBeatmap(const std::string &beatmapPath, bool is_peppy = false);
+    static std::unique_ptr<BeatmapSet> loadRawBeatmap(std::string_view beatmapPath, bool is_peppy = false);
 
-    inline void addPathToImport(const std::string &dbPath) { this->extern_db_paths_to_import.push_back(dbPath); }
+    inline void addPathToImport(std::string_view dbPath) { this->extern_db_paths_to_import.emplace_back(dbPath); }
 
     // locks peppy_overrides mutex and updates overrides for loaded-from-stable-db maps which will be stored in the local database
     void update_overrides(const BeatmapDifficulty *diff);

--- a/src/App/Neomod/Database.h
+++ b/src/App/Neomod/Database.h
@@ -93,8 +93,8 @@ class Database final {
     void cancel();
     void save();
 
-    const BeatmapSet *addBeatmapSet(const std::string &beatmapFolderPath, i32 set_id_override = -1,
-                                    bool is_peppy = false);
+    std::pair<BeatmapSet *, bool /*added*/> addBeatmapSet(const std::string &beatmapFolderPath,
+                                                          i32 set_id_override = -1, bool is_peppy = false);
 
     // returns true if adding succeeded
     bool addScore(const FinishedScore &score);
@@ -134,7 +134,7 @@ class Database final {
     static std::string getOsuSongsFolder();
 
     // only used for raw loading without db
-    std::unique_ptr<BeatmapSet> loadRawBeatmap(const std::string &beatmapPath, bool is_peppy = false);
+    static std::unique_ptr<BeatmapSet> loadRawBeatmap(const std::string &beatmapPath, bool is_peppy = false);
 
     inline void addPathToImport(const std::string &dbPath) { this->extern_db_paths_to_import.push_back(dbPath); }
 
@@ -216,6 +216,8 @@ class Database final {
     void findDatabases();
     bool importDatabase(const std::pair<DatabaseType, std::string> &db_pair);
     void loadMaps(std::string_view neomod_maps_path, std::string_view peppy_db_path);
+    // extract + import loose .osz files from the maps/ drop-zone during the loader's run (before buttons build)
+    void importLooseOsz();
     void loadScores(std::string_view dbPath);
     void loadOldMcNeomodScores(std::string_view dbPath);
     void loadPeppyScores(std::string_view dbPath);

--- a/src/App/Neomod/Database.h
+++ b/src/App/Neomod/Database.h
@@ -109,6 +109,9 @@ class Database final {
     static int getLevelForScore(u64 score, int maxLevel = 120);
 
     [[nodiscard]] inline float getProgress() const { return this->loading_progress.load(std::memory_order_acquire); }
+    // loose .osz import counters for the loading overlay; total stays 0 when nothing is being imported
+    [[nodiscard]] inline u32 getImportDone() const { return this->import_done.load(std::memory_order_acquire); }
+    [[nodiscard]] inline u32 getImportTotal() const { return this->import_total.load(std::memory_order_acquire); }
     [[nodiscard]] inline bool isCancelled() const {
         return this->load_interrupted.load(std::memory_order_acquire) ||
                (this->db_load_handle.valid() && this->db_load_handle.stop.stop_requested());
@@ -201,6 +204,12 @@ class Database final {
     u64 bytes_processed{0};
     u64 total_bytes{0};
     std::atomic<float> loading_progress{0.f};
+
+    // loose .osz import progress for the loading overlay. written by the loader thread in
+    // importLooseOsz, read by the main-thread overlay via getImportDone()/getImportTotal(). total
+    // stays 0 when there's nothing to import.
+    std::atomic<u32> import_done{0};
+    std::atomic<u32> import_total{0};
 
     std::vector<std::string> extern_db_paths_to_import;
     // copy so that more can be added without thread races during loading

--- a/src/App/Neomod/Database.h
+++ b/src/App/Neomod/Database.h
@@ -103,7 +103,7 @@ class Database final {
 
     PlayerPPScores getPlayerPPScores(std::string_view playerName);
     PlayerStats calculatePlayerStats(std::string_view playerName);
-    static float getWeightForIndex(int i);
+    static float getWeightForIndex(uSz i);
     static float getBonusPPForNumScores(size_t numScores);
     static u64 getRequiredScoreForLevel(int level);
     static int getLevelForScore(u64 score, int maxLevel = 120);

--- a/src/App/Neomod/Downloader.cpp
+++ b/src/App/Neomod/Downloader.cpp
@@ -381,7 +381,7 @@ i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name)
     i32 set_id = -1;
     for(const auto& entry : entries) {
         if(entry.isDirectory()) continue;
-        if(env->getFileExtensionFromFilePath(entry.getFilename()) != "osu") continue;
+        if(!entry.getFilename().ends_with(".osu")) continue;
 
         const auto& osu_data = entry.getUncompressedData();
         if(osu_data.empty()) continue;
@@ -409,8 +409,9 @@ i32 read_and_extract_osz(std::string_view path) {
     {
         File osz(path);
         const uSz filesize = osz.getFileSize();
+        if(!osz.canRead() || !filesize) return -1;
         osz_data = FixedSizeArray{osz.takeFileBuffer(), filesize};
-        if(!osz.canRead() || !filesize || !osz_data.data()) return -1;
+        if(!osz_data.data()) return -1;
     }
     return resolve_and_extract_osz(osz_data, Environment::getFileNameFromFilePath(path));
 }

--- a/src/App/Neomod/Downloader.cpp
+++ b/src/App/Neomod/Downloader.cpp
@@ -17,8 +17,11 @@
 #include "Logging.h"
 #include "SongBrowser.h"
 #include "Environment.h"
+#include "File.h"
+#include "FixedSizeArray.h"
 
 #include <atomic>
+#include <cctype>
 #include <memory>
 #include <unordered_map>
 #include <chrono>
@@ -357,7 +360,7 @@ bool extract_beatmapset(std::span<const u8> data, const std::string& map_dir) {
     return write_entries_to_dir(entries, map_dir);
 }
 
-i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name, i32 fallback_id) {
+i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name) {
     debugLog("Reading beatmapset {:s} ({:d} bytes)", osz_name, data.size());
 
     Archive::Reader archive(data);
@@ -373,8 +376,7 @@ i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name,
     }
 
     // single decompression pass: the entries are already in memory, so resolve the set id from the
-    // first .osu that declares one (falling back to the caller-supplied id, e.g. parsed from the .osz
-    // filename) and then write those same buffers to disk without re-extracting.
+    // first .osu that declares one and then write those same buffers to disk without re-extracting.
     i32 set_id = -1;
     for(const auto& entry : entries) {
         if(entry.isDirectory()) continue;
@@ -387,13 +389,29 @@ i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name,
             std::string_view{reinterpret_cast<const char*>(osu_data.data()), osu_data.size()});
         if(set_id != -1) break;
     }
-    if(set_id < 0) set_id = fallback_id;
+
+    // fallback: a leading number in the filename, e.g. "12345 Artist - Title.osz"
+    if(set_id < 0 && !osz_name.empty() && std::isdigit(static_cast<unsigned char>(osz_name.front()))) {
+        i32 parsed = -1;
+        if(Parsing::parse(osz_name, &parsed)) set_id = parsed;
+    }
     if(set_id < 0) return -1;
 
     if(!write_entries_to_dir(entries, fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id))) {
         return -1;
     }
     return set_id;
+}
+
+i32 read_and_extract_osz(std::string_view path) {
+    FixedSizeArray<u8> osz_data;
+    {
+        File osz(path);
+        const uSz filesize = osz.getFileSize();
+        osz_data = FixedSizeArray{osz.takeFileBuffer(), filesize};
+        if(!osz.canRead() || !filesize || !osz_data.data()) return -1;
+    }
+    return resolve_and_extract_osz(osz_data, Environment::getFileNameFromFilePath(path));
 }
 
 bool download_beatmapset(u32 set_id, DownloadHandle& handle) {

--- a/src/App/Neomod/Downloader.cpp
+++ b/src/App/Neomod/Downloader.cpp
@@ -284,13 +284,15 @@ i32 get_beatmapset_id_from_osu_file(std::string_view file) {
 }
 
 // write already-decompressed archive entries into map_dir, creating parent directories as needed.
-// files that can't be written are skipped (validated later when the beatmap is loaded).
+// files that can't be written are skipped (validated later when the beatmap is loaded); returns
+// false if nothing at all could be written.
 bool write_entries_to_dir(const std::vector<Archive::Entry>& entries, std::string_view map_dir) {
     std::string base{map_dir};
     while(base.size() > 1 && (base.back() == '/' || base.back() == '\\')) base.pop_back();
 
     env->createDirectory(base);
 
+    bool wrote_any = false;
     for(const auto& entry : entries) {
         if(entry.isDirectory()) continue;
 
@@ -304,12 +306,14 @@ bool write_entries_to_dir(const std::vector<Archive::Entry>& entries, std::strin
             env->createDirectory(dir_path);
         }
 
-        if(!entry.extractToFile(fmt::format("{}/{}", base, filename))) {
+        if(entry.extractToFile(fmt::format("{}/{}", base, filename))) {
+            wrote_any = true;
+        } else {
             debugLog("Failed to extract file {:s}", filename);
         }
     }
 
-    return true;
+    return wrote_any;
 }
 }  // namespace
 

--- a/src/App/Neomod/Downloader.cpp
+++ b/src/App/Neomod/Downloader.cpp
@@ -282,6 +282,35 @@ i32 get_beatmapset_id_from_osu_file(std::string_view file) {
 
     return -1;
 }
+
+// write already-decompressed archive entries into map_dir, creating parent directories as needed.
+// files that can't be written are skipped (validated later when the beatmap is loaded).
+bool write_entries_to_dir(const std::vector<Archive::Entry>& entries, std::string_view map_dir) {
+    std::string base{map_dir};
+    while(base.size() > 1 && (base.back() == '/' || base.back() == '\\')) base.pop_back();
+
+    env->createDirectory(base);
+
+    for(const auto& entry : entries) {
+        if(entry.isDirectory()) continue;
+
+        const std::string& filename = entry.getFilename();
+        if(filename.find("..") != std::string::npos) continue;  // path traversal guard
+
+        std::string dir_path{base};
+        const auto folders = SString::split(filename, '/');
+        for(size_t i = 0; i + 1 < folders.size(); i++) {
+            dir_path.append("/").append(folders[i]);
+            env->createDirectory(dir_path);
+        }
+
+        if(!entry.extractToFile(fmt::format("{}/{}", base, filename))) {
+            debugLog("Failed to extract file {:s}", filename);
+        }
+    }
+
+    return true;
+}
 }  // namespace
 
 void abort_downloads() {
@@ -306,39 +335,6 @@ DownloadHandle download(std::string_view url) {
     return DownloadHandle{std::move(req)};
 }
 
-i32 extract_beatmapset_id(std::span<const u8> data) {
-    debugLog("Reading beatmapset ({:d} bytes)", data.size());
-    i32 set_id = -1;
-
-    Archive::Reader archive(data);
-    if(!archive.isValid()) {
-        debugLog("Failed to open .osz file");
-        return set_id;
-    }
-
-    auto entries = archive.getAllEntries();
-    if(entries.empty()) {
-        debugLog(".osz file is empty!");
-        return set_id;
-    }
-
-    for(const auto& entry : entries) {
-        if(entry.isDirectory()) continue;
-
-        std::string filename = entry.getFilename();
-        if(env->getFileExtensionFromFilePath(filename).compare("osu") != 0) continue;
-
-        const auto& osu_data = entry.getUncompressedData();
-        if(osu_data.empty()) continue;
-
-        set_id = get_beatmapset_id_from_osu_file(
-            std::string_view{reinterpret_cast<const char*>(osu_data.data()), osu_data.size()});
-        if(set_id != -1) break;
-    }
-
-    return set_id;
-}
-
 bool extract_beatmapset(std::span<const u8> data, const std::string& map_dir) {
     debugLog("Extracting beatmapset ({:d} bytes)", data.size());
 
@@ -354,41 +350,46 @@ bool extract_beatmapset(std::span<const u8> data, const std::string& map_dir) {
         return false;
     }
 
-    if(!env->directoryExists(map_dir)) {
-        env->createDirectory(map_dir);
+    return write_entries_to_dir(entries, map_dir);
+}
+
+i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name, i32 fallback_id) {
+    debugLog("Reading beatmapset {:s} ({:d} bytes)", osz_name, data.size());
+
+    Archive::Reader archive(data);
+    if(!archive.isValid()) {
+        debugLog("Failed to open .osz file");
+        return -1;
     }
 
+    auto entries = archive.getAllEntries();
+    if(entries.empty()) {
+        debugLog(".osz file is empty!");
+        return -1;
+    }
+
+    // single decompression pass: the entries are already in memory, so resolve the set id from the
+    // first .osu that declares one (falling back to the caller-supplied id, e.g. parsed from the .osz
+    // filename) and then write those same buffers to disk without re-extracting.
+    i32 set_id = -1;
     for(const auto& entry : entries) {
         if(entry.isDirectory()) continue;
+        if(env->getFileExtensionFromFilePath(entry.getFilename()) != "osu") continue;
 
-        std::string filename = entry.getFilename();
-        const auto folders = SString::split(filename, '/');
-        std::string file_path = map_dir;
+        const auto& osu_data = entry.getUncompressedData();
+        if(osu_data.empty()) continue;
 
-        for(const auto& folder : folders) {
-            if(!env->directoryExists(file_path)) {
-                env->createDirectory(file_path);
-            }
-
-            if(folder == "..") {
-                // security check: skip files with path traversal attempts
-                goto skip_file;
-            } else {
-                file_path.append("/");
-                file_path.append(folder);
-            }
-        }
-
-        if(!entry.extractToFile(file_path)) {
-            debugLog("Failed to extract file {:s}", filename.c_str());
-        }
-
-    skip_file:;
-        // when a file can't be extracted we just ignore it (as long as the archive is valid)
-        // we'll check for errors when loading the beatmap
+        set_id = get_beatmapset_id_from_osu_file(
+            std::string_view{reinterpret_cast<const char*>(osu_data.data()), osu_data.size()});
+        if(set_id != -1) break;
     }
+    if(set_id < 0) set_id = fallback_id;
+    if(set_id < 0) return -1;
 
-    return true;
+    if(!write_entries_to_dir(entries, fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id))) {
+        return -1;
+    }
+    return set_id;
 }
 
 bool download_beatmapset(u32 set_id, DownloadHandle& handle) {

--- a/src/App/Neomod/Downloader.cpp
+++ b/src/App/Neomod/Downloader.cpp
@@ -300,7 +300,8 @@ bool write_entries_to_dir(const std::vector<Archive::Entry>& entries, std::strin
         if(entry.isDirectory()) continue;
 
         const std::string& filename = entry.getFilename();
-        if(filename.find("..") != std::string::npos) continue;  // path traversal guard
+        if(filename.find("../") != std::string::npos || filename.find("..\\") != std::string::npos)
+            continue;  // path traversal guard
 
         std::string dir_path{base};
         const auto folders = SString::split(filename, '/');

--- a/src/App/Neomod/Downloader.h
+++ b/src/App/Neomod/Downloader.h
@@ -65,7 +65,11 @@ i32 resolve_beatmapset_id_for(i32 beatmap_id, i32 set_id_hint = 0);
 
 void process_beatmapset_info_response(const Packet &packet);
 
-i32 extract_beatmapset_id(std::span<const u8> data);
+// extract an archive whose beatmapset id is already known, into map_dir.
 bool extract_beatmapset(std::span<const u8> data, const std::string &map_dir);
+
+// extract a local .osz: resolves the beatmapset id from the archive (or fallback_id if the .osu files
+// don't declare one), extracts into maps/<id>/, and returns the resolved id (-1 if no valid id).
+i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name, i32 fallback_id);
 
 }  // namespace Downloader

--- a/src/App/Neomod/Downloader.h
+++ b/src/App/Neomod/Downloader.h
@@ -68,8 +68,13 @@ void process_beatmapset_info_response(const Packet &packet);
 // extract an archive whose beatmapset id is already known, into map_dir.
 bool extract_beatmapset(std::span<const u8> data, const std::string &map_dir);
 
-// extract a local .osz: resolves the beatmapset id from the archive (or fallback_id if the .osu files
-// don't declare one), extracts into maps/<id>/, and returns the resolved id (-1 if no valid id).
-i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name, i32 fallback_id);
+// extract a local .osz already in memory: resolves the beatmapset id from the archive (or, failing
+// that, a leading number in osz_name), extracts into maps/<id>/, and returns the resolved id (-1 if
+// none).
+i32 resolve_and_extract_osz(std::span<const u8> data, std::string_view osz_name);
+
+// read a local .osz from disk and extract it via resolve_and_extract_osz. returns the resolved set id
+// (> 0) or <= 0 on failure. does blocking file I/O + decompression, so call it off the main thread.
+i32 read_and_extract_osz(std::string_view path);
 
 }  // namespace Downloader

--- a/src/App/Neomod/MainMenu.cpp
+++ b/src/App/Neomod/MainMenu.cpp
@@ -1208,7 +1208,7 @@ void MainMenu::selectRandomBeatmap() {
         constexpr int RETRY_SETS{10};
         for(int i = 0; i < RETRY_SETS; i++) {
             const auto &mapset_folder = this->songsFolderEntries[prand() % this->songsFolderEntries.size()];
-            auto set = db->loadRawBeatmap(mapset_folder);
+            auto set = Database::loadRawBeatmap(mapset_folder);
             if(set == nullptr) {
                 // loadRawBeatmap will log failure with reason
                 // debugLog("Failed to load beatmap set '{:s}'", mapset_folder.c_str());

--- a/src/App/Neomod/NeomodEnvInterop.cpp
+++ b/src/App/Neomod/NeomodEnvInterop.cpp
@@ -2,15 +2,12 @@
 #include "Environment.h"
 
 #include "OsuConVars.h"
+#include "BeatmapInstaller.h"
 #include "Database.h"
 #include "DatabaseBeatmap.h"
-#include "Downloader.h"  // for extract_beatmapset
-#include "File.h"
-#include "FixedSizeArray.h"
 #include "NeomodUrl.h"
 #include "OptionsOverlay.h"
 #include "Osu.h"
-#include "Parsing.h"
 #include "RankingScreen.h"
 #include "Skin.h"
 #include "SongBrowser/SongBrowser.h"
@@ -52,67 +49,12 @@ bool handle_osk(std::string_view osk_path) {
     return true;
 }
 
-const BeatmapSet *handle_osz(std::string_view osz_path) {
-    if(!osu) return nullptr;
-
-    if(osu->isInPlayMode()) {
-        ui->getNotificationOverlay()->addToast(fmt::format("Can't import {} while playing.", osz_path), ERROR_TOAST);
-        return nullptr;
-    } else if(!db->isFinished() || db->isCancelled()) {
-        ui->getNotificationOverlay()->addToast(fmt::format("Can't import {} before songs have been loaded.", osz_path),
-                                               ERROR_TOAST);
-        return nullptr;
-    }
-
-    FixedSizeArray<u8> osz_data;
-    {
-        File osz(osz_path);
-        uSz osz_filesize = osz.getFileSize();
-        osz_data = FixedSizeArray{osz.takeFileBuffer(), osz_filesize};
-        if(!osz.canRead() || !osz_filesize || !osz_data.data()) {
-            ui->getNotificationOverlay()->addToast(fmt::format("Failed to import {}", osz_path), ERROR_TOAST);
-            return nullptr;
-        }
-    }
-
-    i32 set_id = Downloader::extract_beatmapset_id(osz_data);
-    if(set_id < 0) {
-        // special case: legacy fallback behavior for invalid beatmapSetID, try to parse the ID from the
-        // path
-        std::string mapset_name = Environment::getFileNameFromFilePath(osz_path);
-        if(!mapset_name.empty() && std::isdigit(static_cast<unsigned char>(mapset_name[0]))) {
-            if(!Parsing::parse(mapset_name, &set_id)) {
-                set_id = -1;
-            }
-        }
-    }
-    if(set_id == -1) {
-        ui->getNotificationOverlay()->addToast("Beatmapset doesn't have a valid ID.", ERROR_TOAST);
-        return nullptr;
-    }
-
-    std::string mapset_dir = fmt::format(NEOMOD_MAPS_PATH "/{}/", set_id);
-    Environment::createDirectory(mapset_dir);
-    if(!Downloader::extract_beatmapset(osz_data, mapset_dir)) {
-        ui->getNotificationOverlay()->addToast("Failed to extract beatmapset", ERROR_TOAST);
-        return nullptr;
-    }
-
-    const BeatmapSet *set = db->addBeatmapSet(mapset_dir, set_id);
-    if(!set) {
-        ui->getNotificationOverlay()->addToast("Failed to import beatmapset", ERROR_TOAST);
-        return nullptr;
-    }
-
-    return set;
-}
-
 bool NeomodEnvInterop::handle_cmdline_args(const std::vector<std::string> &args) {
     if(!osu || !db) return false;
     using namespace neomod;
 
     bool got_db_related_import = false;
-    std::vector<std::string> db_dependent_imports;
+    std::vector<std::string> replay_imports;
     bool need_to_reload_database = false;
 
     for(const auto &arg : args) {
@@ -133,8 +75,14 @@ bool NeomodEnvInterop::handle_cmdline_args(const std::vector<std::string> &args)
             if(!extension.empty()) {
                 debugLog("Handling {}...", arg);
 
-                if(extension == "osz" || extension == "osr") {
-                    db_dependent_imports.push_back(arg);
+                if(extension == "osz") {
+                    // external file: import async through the installer and navigate to it, but never
+                    // delete the user's file. the installer defers the import until the db is loaded.
+                    osu->getBeatmapInstaller()->enqueue_local(arg, /*auto_select=*/true, /*delete_after=*/false);
+                    need_to_reload_database |= (!db->isFinished() || db->isCancelled());
+                    got_db_related_import = true;
+                } else if(extension == "osr") {
+                    replay_imports.push_back(arg);
                     need_to_reload_database |= (!db->isFinished() || db->isCancelled());
                     got_db_related_import = true;
                 } else if(extension == "osk" || extension == "zip") {
@@ -155,23 +103,16 @@ bool NeomodEnvInterop::handle_cmdline_args(const std::vector<std::string> &args)
     if(!osu->isInPlayMode()) {
         SongBrowser *sbr = ui->getSongBrowser();
         RankingScreen *rankingscreen = ui->getRankingScreen();
-        auto finish_importing = [sbr, rankingscreen, notif = ui->getNotificationOverlay(), db_dependent_imports] {
-            const BeatmapSet *last_imported_set = nullptr;
+        // .osz imports run through the installer (enqueued above); only replays need post-load handling.
+        auto finish_importing = [sbr, rankingscreen, notif = ui->getNotificationOverlay(), replay_imports] {
             FinishedScore last_imported_replay;
 
-            for(const auto &path : db_dependent_imports) {
-                auto extension = Environment::getFileExtensionFromFilePath(path);
-                if(extension == "osz"sv) {
-                    if(const auto *imported = handle_osz(path)) {
-                        last_imported_set = imported;
-                    }
-                } else if(extension == "osr") {
-                    FinishedScore replay;
-                    if(LegacyReplay::load_osr(path, replay)) {
-                        last_imported_replay = replay;
-                    } else {
-                        notif->addToast("Failed to load replay.", ERROR_TOAST);
-                    }
+            for(const auto &path : replay_imports) {
+                FinishedScore replay;
+                if(LegacyReplay::load_osr(path, replay)) {
+                    last_imported_replay = replay;
+                } else {
+                    notif->addToast("Failed to load replay.", ERROR_TOAST);
                 }
             }
 
@@ -186,8 +127,6 @@ bool NeomodEnvInterop::handle_cmdline_args(const std::vector<std::string> &args)
                     // TODO: auto-download
                     notif->addToast("This replay's beatmap is not installed.", ERROR_TOAST);
                 }
-            } else if(last_imported_set != nullptr) {
-                sbr->selectBeatmapset(last_imported_set);
             }
         };
 

--- a/src/App/Neomod/NeomodEnvInterop.h
+++ b/src/App/Neomod/NeomodEnvInterop.h
@@ -5,15 +5,12 @@
 #define NEOMODENVINTEROP_H
 
 #include <string_view>
-class DatabaseBeatmap;
-using BeatmapSet = DatabaseBeatmap;
 
 // TODO: maybe these should be static members of Osu:: ?
 namespace neomod {
 void *createInterop(void *envptr);
 void handleExistingWindow(int argc, char *argv[]);
 
-const BeatmapSet *handle_osz(std::string_view osz_path);
 bool handle_osk(std::string_view osk_path);
 }  // namespace neomod
 

--- a/src/App/Neomod/Osu.cpp
+++ b/src/App/Neomod/Osu.cpp
@@ -578,13 +578,16 @@ void Osu::update() {
         this->doChangeFocus(focused);
     }
 
-    // online beatmap downloads and thumbnails (avatars/beatmap thumbnails) are currently only relevant when online
+    // beatmap imports: local .osz files (drag-drop, file association, maps/ watcher) can arrive while
+    // offline, so the installer must tick regardless of online status. download entries are only ever
+    // enqueued from online UI (osu!direct/multiplayer/spectator), so ticking offline is harmless.
+    // gated out of play mode so we don't auto-select a map mid-gameplay.
+    if(!this->isInPlayMode()) {
+        this->beatmapInstaller->update();
+    }
+
+    // thumbnails (avatars/beatmap thumbnails) are currently only relevant when online
     if(BanchoState::is_online()) {
-        // update background beatmap downloads
-        // (gated differently from thumbnails so that we don't auto-select a map while playing)
-        if(!this->isInPlayMode()) {
-            this->beatmapInstaller->update();
-        }
         // XXX: there are too many flags/states to individually check whether or not we're in a "low-latency session" or not
         // TODO: offline/local avatars?
         if(!this->isInPlayModeAndNotPaused() || this->map_iface->isInBreak() ||

--- a/src/App/Neomod/SongBrowser/SongBrowser.cpp
+++ b/src/App/Neomod/SongBrowser/SongBrowser.cpp
@@ -2500,13 +2500,8 @@ void SongBrowser::initializeGroupingButtons() {
 }
 
 void SongBrowser::onDatabaseLoadingFinished() {
-    // Extract oszs from neomod's maps/ directory now
-    auto oszs = env->getFilesInFolder(NEOMOD_MAPS_PATH "/");
-    for(const auto &file : oszs) {
-        if(env->getFileExtensionFromFilePath(file) != "osz") continue;
-        auto path = NEOMOD_MAPS_PATH "/" + file;
-        if(neomod::handle_osz(path)) env->deleteFile(path);
-    }
+    // loose .osz files dropped into maps/ were already extracted + imported by the loader stage
+    // (Database::importLooseOsz), so by the time we get here the database already contains them.
 
     Timer t;
     t.start();
@@ -2587,13 +2582,11 @@ void SongBrowser::onDatabaseLoadingFinished() {
     // Watch for new maps now
     directoryWatcher->watch_directory(NEOMOD_MAPS_PATH "/", [](const FileChangeEvent &ev) {
         if(ev.type != FileChangeType::CREATED) return;
-        logRaw("[DirectoryWatcher] Importing new beatmap {}: type {}", ev.path, (u32)ev.type);
         if(env->getFileExtensionFromFilePath(ev.path) != "osz") return;
+        logRaw("[DirectoryWatcher] Importing new beatmap {}", ev.path);
 
-        if(const BeatmapSet *set = neomod::handle_osz(ev.path)) {
-            env->deleteFile(ev.path);
-            ui->getSongBrowser()->selectBeatmapset(set);
-        }
+        // drop-zone file: import async via the installer, navigate to it, and delete the .osz on success.
+        osu->getBeatmapInstaller()->enqueue_local(ev.path, /*auto_select=*/true, /*delete_after=*/true);
     });
 }
 

--- a/src/App/Neomod/SongBrowser/SongBrowser.cpp
+++ b/src/App/Neomod/SongBrowser/SongBrowser.cpp
@@ -1445,6 +1445,29 @@ class SongBrowser::BeatmapLoadingOverlay final : public LoadingScreen {
         return db->getProgress();
     }
 
+    void drawProgress() override {
+        LoadingScreen::drawProgress();
+
+        // loose .osz imports aren't part of the byte-based percentage, so without this the bar just
+        // sits pinned near the end with no sign of progress while a big drop extracts. surface the count.
+        const u32 total = db->getImportTotal();
+        if(total == 0) return;
+
+        auto *font = osu->getSubTitleFont();
+        const f32 shadowOffset = std::round(1.0f * Osu::getUIScale());
+        const std::string msg = tformat("Importing beatmaps ({:d}/{:d})", db->getImportDone(), total);
+
+        g->setColor(0xffffffff);
+        g->pushTransform();
+        {
+            g->translate((int)(osu->getVirtScreenWidth() / 2 - font->getStringWidth(msg) / 2),
+                         (int)(osu->getVirtScreenHeight() - 15 - font->getHeight() - 5.0f * Osu::getUIScale()));
+            g->drawString(font, msg,
+                          TextFX{.col_text = rgb(255, 255, 255), .col_shadow = rgb(0, 0, 0), .offs_px = shadowOffset});
+        }
+        g->popTransform();
+    }
+
     void finish() override {
         this->progress = 1.f;
 

--- a/src/App/Tests/AsyncPoolTest.cpp
+++ b/src/App/Tests/AsyncPoolTest.cpp
@@ -162,7 +162,7 @@ void AsyncPoolTest::runSyncTests() {
 
     TEST_SECTION("thread_count");
     {
-        TEST_ASSERT(AsyncPool::get().thread_count() >= 1, "pool has at least 1 thread");
+        TEST_ASSERT(Async::get_thread_count() >= 1, "pool has at least 1 thread");
     }
 
     TEST_SECTION("submit_cancellable");
@@ -220,7 +220,7 @@ void AsyncPoolTest::runSyncTests() {
 
     TEST_SECTION("thread_count >= 2");
     {
-        TEST_ASSERT(AsyncPool::get().thread_count() >= 2, "pool has at least 2 threads");
+        TEST_ASSERT(Async::get_thread_count() >= 2, "pool has at least 2 threads");
     }
 
     TEST_SECTION("channel push + drain");

--- a/src/Engine/Async/AsyncPool.h
+++ b/src/Engine/Async/AsyncPool.h
@@ -148,6 +148,8 @@ class AsyncPool final {
 // ---------------------------------------------------------------------------
 namespace Async {
 
+inline size_t get_thread_count() { return AsyncPool::get().thread_count(); }
+
 template <typename F>
 auto submit(F&& f, Lane lane = Lane::Foreground) -> Future<std::invoke_result_t<F>> {
     return AsyncPool::get().submit(std::forward<F>(f), lane);

--- a/src/Engine/Resources/ResourceManager/AsyncResourceLoader.cpp
+++ b/src/Engine/Resources/ResourceManager/AsyncResourceLoader.cpp
@@ -12,7 +12,7 @@
 #include <utility>
 
 AsyncResourceLoader::AsyncResourceLoader()
-    : iLoadsPerUpdate(static_cast<size_t>(std::ceil(static_cast<double>(AsyncPool::get().thread_count()) * (1. / 4.)))),
+    : iLoadsPerUpdate(static_cast<size_t>(std::ceil(static_cast<double>(Async::get_thread_count()) * (1. / 4.)))),
       iLoadsPerUpdateFloor(iLoadsPerUpdate) {}
 
 AsyncResourceLoader::~AsyncResourceLoader() { shutdown(); }

--- a/src/GUI/Windows/VisualProfiler.cpp
+++ b/src/GUI/Windows/VisualProfiler.cpp
@@ -219,7 +219,7 @@ void VisualProfiler::draw() {
                                 this->textLines);
                     addTextLine(fmt::format("Sound Volume: {:f}"_cf, soundEngine->getVolume()), textFont,
                                 this->textLines);
-                    addTextLine(fmt::format("Pool: {:d} threads, {:d} pending"_cf, AsyncPool::get().thread_count(),
+                    addTextLine(fmt::format("Pool: {:d} threads, {:d} pending"_cf, Async::get_thread_count(),
                                             AsyncPool::get().pending_count()),
                                 textFont, this->textLines);
                     addTextLine(fmt::format("RM InFlight: {:d}, DestroyQ: {:d}"_cf, resourceManager->getNumInFlight(),

--- a/src/pch.h
+++ b/src/pch.h
@@ -9,6 +9,7 @@
 #include "MD5Hash.h"
 #include "Color.h"
 #include "Rect.h"  // mostly due to formatters
+#include "ContainerRanges.h"
 
 #include "SyncMutex.h"
 #include "SyncCV.h"

--- a/translations/de.po
+++ b/translations/de.po
@@ -3150,6 +3150,11 @@ msgid "Failed to find Beatmap #{:d} :("
 msgstr "Konnte Beatmap #{:d} nicht finden :("
 
 #: src/App/Neomod/SongBrowser/SongBrowser.cpp
+#, fuzzy, c++-format
+msgid "Importing beatmaps ({:d}/{:d})"
+msgstr "Start erzwingen ({:d}/{:d})"
+
+#: src/App/Neomod/SongBrowser/SongBrowser.cpp
 msgid "0-9"
 msgstr "0-9"
 

--- a/translations/de.po
+++ b/translations/de.po
@@ -41,6 +41,11 @@ msgid "Downloaded beatmapset #{:d}"
 msgstr "Beatmapset #{:d} heruntergeladen"
 
 #: src/App/Neomod/BeatmapInstaller.cpp
+#, fuzzy, c++-format
+msgid "Failed to import {}"
+msgstr "Laden der Map fehlgeschlagen"
+
+#: src/App/Neomod/BeatmapInstaller.cpp
 #, c++-format
 msgid "Failed to download beatmapset #{:d} :("
 msgstr "Herunterladen von Beatmapset #{:d} fehlgeschlagen :("

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -3134,6 +3134,11 @@ msgid "Failed to find Beatmap #{:d} :("
 msgstr "Impossible de trouver la beatmap #{:d} :("
 
 #: src/App/Neomod/SongBrowser/SongBrowser.cpp
+#, fuzzy, c++-format
+msgid "Importing beatmaps ({:d}/{:d})"
+msgstr "Forcer le démarrage ({:d}/{:d})"
+
+#: src/App/Neomod/SongBrowser/SongBrowser.cpp
 msgid "0-9"
 msgstr "0-9"
 

--- a/translations/fr.po
+++ b/translations/fr.po
@@ -34,6 +34,11 @@ msgid "Downloaded beatmapset #{:d}"
 msgstr "Mapset #{:d} téléchargé"
 
 #: src/App/Neomod/BeatmapInstaller.cpp
+#, fuzzy, c++-format
+msgid "Failed to import {}"
+msgstr "Échec du chargement de la map"
+
+#: src/App/Neomod/BeatmapInstaller.cpp
 #, c++-format
 msgid "Failed to download beatmapset #{:d} :("
 msgstr "Échec du téléchargement du mapset #{:d} :("

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -3150,6 +3150,11 @@ msgid "Failed to find Beatmap #{:d} :("
 msgstr "ビートマップ #{:d} が見つかりませんでした :("
 
 #: src/App/Neomod/SongBrowser/SongBrowser.cpp
+#, fuzzy, c++-format
+msgid "Importing beatmaps ({:d}/{:d})"
+msgstr "強制スタート ({:d}/{:d})"
+
+#: src/App/Neomod/SongBrowser/SongBrowser.cpp
 msgid "0-9"
 msgstr "0-9"
 

--- a/translations/ja.po
+++ b/translations/ja.po
@@ -41,6 +41,11 @@ msgid "Downloaded beatmapset #{:d}"
 msgstr "ビートマップセット #{:d} をダウンロードしました"
 
 #: src/App/Neomod/BeatmapInstaller.cpp
+#, fuzzy, c++-format
+msgid "Failed to import {}"
+msgstr "マップの読み込みに失敗しました"
+
+#: src/App/Neomod/BeatmapInstaller.cpp
 #, c++-format
 msgid "Failed to download beatmapset #{:d} :("
 msgstr "ビートマップセット #{:d} のダウンロードに失敗しました :("

--- a/translations/neomod.pot
+++ b/translations/neomod.pot
@@ -3019,6 +3019,11 @@ msgid "Failed to find Beatmap #{:d} :("
 msgstr ""
 
 #: src/App/Neomod/SongBrowser/SongBrowser.cpp
+#, c++-format
+msgid "Importing beatmaps ({:d}/{:d})"
+msgstr ""
+
+#: src/App/Neomod/SongBrowser/SongBrowser.cpp
 msgid "0-9"
 msgstr ""
 

--- a/translations/neomod.pot
+++ b/translations/neomod.pot
@@ -17,6 +17,11 @@ msgstr ""
 
 #: src/App/Neomod/BeatmapInstaller.cpp
 #, c++-format
+msgid "Failed to import {}"
+msgstr ""
+
+#: src/App/Neomod/BeatmapInstaller.cpp
+#, c++-format
 msgid "Failed to download beatmapset #{:d} :("
 msgstr ""
 

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -3167,6 +3167,11 @@ msgid "Failed to find Beatmap #{:d} :("
 msgstr "Nie udało się znaleźć Beatmapy #{:d} :("
 
 #: src/App/Neomod/SongBrowser/SongBrowser.cpp
+#, fuzzy, c++-format
+msgid "Importing beatmaps ({:d}/{:d})"
+msgstr "Wymuś start ({:d}/{:d})"
+
+#: src/App/Neomod/SongBrowser/SongBrowser.cpp
 msgid "0-9"
 msgstr "0-9"
 

--- a/translations/pl.po
+++ b/translations/pl.po
@@ -41,6 +41,11 @@ msgid "Downloaded beatmapset #{:d}"
 msgstr "Pobrano zestaw beatmap #{:d}"
 
 #: src/App/Neomod/BeatmapInstaller.cpp
+#, fuzzy, c++-format
+msgid "Failed to import {}"
+msgstr "Nie udało się załadować mapy"
+
+#: src/App/Neomod/BeatmapInstaller.cpp
 #, c++-format
 msgid "Failed to download beatmapset #{:d} :("
 msgstr "Nie udało się pobrać zestawu beatmap #{:d} :("

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -3164,6 +3164,11 @@ msgid "Failed to find Beatmap #{:d} :("
 msgstr "Не удалось найти Карту #{:d} :("
 
 #: src/App/Neomod/SongBrowser/SongBrowser.cpp
+#, fuzzy, c++-format
+msgid "Importing beatmaps ({:d}/{:d})"
+msgstr "Принудительный старт ({:d}/{:d})"
+
+#: src/App/Neomod/SongBrowser/SongBrowser.cpp
 msgid "0-9"
 msgstr "0-9"
 

--- a/translations/ru.po
+++ b/translations/ru.po
@@ -41,6 +41,11 @@ msgid "Downloaded beatmapset #{:d}"
 msgstr "Скачан набор карт #{:d}"
 
 #: src/App/Neomod/BeatmapInstaller.cpp
+#, fuzzy, c++-format
+msgid "Failed to import {}"
+msgstr "Не удалось загрузить карту"
+
+#: src/App/Neomod/BeatmapInstaller.cpp
 #, c++-format
 msgid "Failed to download beatmapset #{:d} :("
 msgstr "Не удалось скачать набор карт #{:d} :("


### PR DESCRIPTION
TODOs:

- [x] slow (for a lot of maps at once)
- [x] stuck loading progress at 99%
- [x] song browser jumping around when importing stuff after load (i.e. directorywatcher)
- [x] loudness normalization doesn't seem to work until reload/restart or something
- [ ] ~~should probably allow manually "fixing" db by re-parsing maps/ folder from scratch (of already extracted maps)~~
  - [ ] ~~consolidate with "peppy raw load"~~
- [ ] ~~(maybe?) try to deduplicate/consolidate local and online beatmap install logic a bit~~

~~good enough to look at for a first attempt though~~

(should): 
~~c l o s e #174~~ (out of scope, too much at once...)
close #142